### PR TITLE
Update README.md

### DIFF
--- a/bridge/native/README.md
+++ b/bridge/native/README.md
@@ -80,7 +80,7 @@ You can fetch existing withdrawals with
 npx hardhat fetchWithdrawals
 ```
 
-Withdrawals will have 4 booleans to indicate it's lifecycle.
+Withdrawals will have 4 booleans to indicate its lifecycle.
 isReadyToProve, isProven, isReadyToFinalize, and isFinalized
 
 To initiate a native token withdrawal, start with


### PR DESCRIPTION
"Withdrawals will have 4 booleans to indicate it's lifecycle." - "it's" should be "its" as it is possessive, not a contraction of "it is".